### PR TITLE
[cherry-pick to main] nuke `lint`

### DIFF
--- a/molecule/kind/molecule.yml
+++ b/molecule/kind/molecule.yml
@@ -47,9 +47,6 @@ provisioner:
     KIND_PORT: '${TEST_CLUSTER_PORT:-10443}'
 verifier:
   name: ansible
-  lint: |
-    set -e
-    ansible-lint
 scenario:
   name: kind
   test_sequence:


### PR DESCRIPTION
Discovered in https://github.com/migtools/mig-legacy-operator/pull/28

https://github.com/migtools/mig-legacy-operator/actions/runs/3370087906/jobs/5590541631#step:4:7

```
Run molecule test -s kind
  molecule test -s kind
  shell: /usr/bin/bash -e {0}
CRITICAL Failed to validate /home/runner/work/mig-legacy-operator/mig-legacy-operator/molecule/kind/molecule.yml

["Additional properties are not allowed ('lint' was unexpected)"]
Error: Process completed with exit code 1.
```

Investigation leads to introduction of changes in molecule ~~4.0.3.  I don't see this failure using 4.0.0.

Reference:

https://github.com/ansible-community/molecule/issues?q=is%3Aissue+Additional+properties+are+not+allowed